### PR TITLE
fix: ensure ping plays on first call

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,8 +55,11 @@ function ping(a = 0.15, b, c) {
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
     const o = ctx.createOscillator(); const g = ctx.createGain();
     o.type = "sine"; o.frequency.setValueAtTime(freq, ctx.currentTime);
-    g.gain.value = volume; o.connect(g).connect(ctx.destination); o.start();
-    setTimeout(() => { o.stop(); ctx.close(); }, duration);
+    g.gain.value = volume; o.connect(g).connect(ctx.destination);
+    ctx.resume().then(() => {
+      o.start();
+      setTimeout(() => { o.stop(); ctx.close(); }, duration);
+    });
   } catch {}
 }
 


### PR DESCRIPTION
## Summary
- resume audio context in `ping` before starting oscillator to ensure initial sound plays

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac85d8d58483299ce8ad74d32f65d3